### PR TITLE
First pass at fixing FLSun's mishandling of EEPROM data

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -70,7 +70,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Cyril Guislain, SuperRacer Nano V3)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Cyril Guislain, Brandon Salahat, SuperRacer Nano V3)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 /**

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1269,41 +1269,8 @@ void setup() {
 
   SETUP_LOG("setup() completed.");
 
-  if(Flsun_language == 1)//英语 新增
-  {
-    change_en();
-  }
-  else if(Flsun_language == 2)//中文简体
-  {
-    change_zh_CN();
-  }
-  else if(Flsun_language == 3)//中文繁体
-  {
-    change_zh_TW();
-  }
-  else if(Flsun_language == 4)//俄语
-  {
-    change_ru();
-  }
-  else if(Flsun_language == 5)//法语
-  {
-    change_fr();
-  }
-  else if(Flsun_language == 6)//西班牙语
-  {
-    change_es();
-  }
-  else if(Flsun_language == 7)//德语
-  {
-    change_de();
-  }
-  else if(Flsun_language == 8)//日语
-  {
-    change_jp();
-  }
-  char cmd[5] = {0};//新增
-  sprintf_P(cmd,"%ld",total_time/60);
-  print_thr_adress_string(0x17,0x00,cmd);
+  setFLSunLanguage(Flsun_language);
+  setFLSunHours(total_time);
   print_thr_adress_string(0x13,0x40,"V1.2.1");//显示版本号
   print_thr_adress_string(0x13,0x30,"Marlin 2.0.8");//显示版本号
   if(recovery.exists())//新增
@@ -1316,6 +1283,47 @@ void setup() {
     jump_to(01);
   }
   
+}
+
+void setFLSunHours(const millis_t time) {
+  char cmd[5] = {0};//新增
+  sprintf_P(cmd,"%ld",time/60);
+  print_thr_adress_string(0x17,0x00,cmd);
+}
+
+void setFLSunLanguage(const uint16_t lang) {
+  if(lang == 1)//英语 新增
+  {
+    change_en();
+  }
+  else if(lang == 2)//中文简体
+  {
+    change_zh_CN();
+  }
+  else if(lang == 3)//中文繁体
+  {
+    change_zh_TW();
+  }
+  else if(lang == 4)//俄语
+  {
+    change_ru();
+  }
+  else if(lang == 5)//法语
+  {
+    change_fr();
+  }
+  else if(lang == 6)//西班牙语
+  {
+    change_es();
+  }
+  else if(lang == 7)//德语
+  {
+    change_de();
+  }
+  else if(lang == 8)//日语
+  {
+    change_jp();
+  }
 }
 
 /**

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -32,6 +32,8 @@
 #include <stdlib.h>
 
 void stop();
+void setFLSunLanguage(const uint16_t lang);
+void setFLSunHours(const millis_t time);
 
 // Pass true to keep steppers from timing out
 void idle(TERN_(ADVANCED_PAUSE_FEATURE, bool no_stepper_sleep=false));

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -360,11 +360,6 @@
   #endif
 #endif
 
-// If platform requires early initialization of watchdog to properly boot
-#if ENABLED(USE_WATCHDOG) && defined(ARDUINO_ARCH_SAM)
-  #define EARLY_WATCHDOG 1
-#endif
-
 // Full Touch Screen needs 'tft/xpt2046'
 #if EITHER(TOUCH_SCREEN, HAS_TFT_LVGL_UI)
   #define HAS_TFT_XPT2046 1

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -387,12 +387,10 @@ void _internal_move_to_destination(const feedRate_t &fr_mm_s/*=0.0f*/
     planner.e_factor[active_extruder] = 1.0f;
   #endif
 
-  #if IS_KINEMATIC
-    if (is_fast)
-      prepare_fast_move_to_destination();
-    else
-  #endif
-      prepare_line_to_destination();
+  if (TERN0(IS_KINEMATIC, is_fast))
+    TERN(IS_KINEMATIC, prepare_fast_move_to_destination(), NOOP);
+  else
+    prepare_line_to_destination();
 
   feedrate_mm_s = old_feedrate;
   feedrate_percentage = old_pct;

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -36,7 +36,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V83"
+#define EEPROM_VERSION "V84"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -151,6 +151,11 @@
 
 #if ENABLED(SOUND_MENU_ITEM)
   #include "../libs/buzzer.h"
+#endif
+
+#if ENABLED(DGUS_LCD_UI_MKS)
+  #include "../lcd/extui/lib/dgus/DGUSScreenHandler.h"
+  #include "../lcd/extui/lib/dgus/DGUSDisplayDef.h"
 #endif
 
 #pragma pack(push, 1) // No padding between variables
@@ -279,7 +284,7 @@ typedef struct SettingsDataStruct {
     abc_float_t delta_endstop_adj;                      // M666 X Y Z
     float delta_radius,                                 // M665 R
           delta_diagonal_rod,                           // M665 L
-          delta_segments_per_second;                    // M665 S
+          segments_per_second;                          // M665 S
     abc_float_t delta_tower_angle_trim,                 // M665 X Y Z
                 delta_diagonal_rod_trim;                // M665 A B C
   #elif HAS_EXTRA_ENDSTOPS
@@ -317,6 +322,11 @@ typedef struct SettingsDataStruct {
   // PIDTEMPBED
   //
   PID_t bedPID;                                         // M304 PID / M303 E-1 U
+
+  //
+  // PIDTEMPCHAMBER
+  //
+  PID_t chamberPID;                                     // M309 PID / M303 E-2 U
 
   //
   // User-defined Thermistors
@@ -456,9 +466,22 @@ typedef struct SettingsDataStruct {
     bool buzzer_enabled;
   #endif
 
+  //
+  // MKS UI controller
+  //
+  #if ENABLED(DGUS_LCD_UI_MKS)
+    uint8_t mks_language_index;                         // Display Language
+    xy_int_t mks_corner_offsets[5];                     // Bed Tramming
+    xyz_int_t mks_park_pos;                             // Custom Parking (without NOZZLE_PARK)
+    celsius_t mks_min_extrusion_temp;                   // Min E Temp (shadow M302 value)
+  #endif
+
   #if HAS_MULTI_LANGUAGE
     uint8_t ui_language;                                // M414 S
   #endif
+
+  uint16_t Flsun_language;
+  millis_t total_time;
 
 } SettingsData;
 
@@ -512,6 +535,8 @@ void MarlinSettings::postprocess() {
   TERN_(HAS_LINEAR_E_JERK, planner.recalculate_max_e_jerk());
 
   TERN_(CASELIGHT_USES_BRIGHTNESS, caselight.update_brightness());
+
+  TERN_(EXTENSIBLE_UI, ExtUI::onPostprocessSettings());
 
   // Refresh steps_to_mm with the reciprocal of axis_steps_per_mm
   // and init stepper.count[], planner.position[] with current_position
@@ -567,13 +592,6 @@ void MarlinSettings::postprocess() {
 
 #if ENABLED(EEPROM_SETTINGS)
 
-  #define EEPROM_START()          if (!persistentStore.access_start()) { SERIAL_ECHO_MSG("No EEPROM."); return false; } \
-                                  int eeprom_index = EEPROM_OFFSET
-  #define EEPROM_FINISH()         persistentStore.access_finish()
-  #define EEPROM_SKIP(VAR)        (eeprom_index += sizeof(VAR))
-  #define EEPROM_WRITE(VAR)       do{ persistentStore.write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc);              }while(0)
-  #define EEPROM_READ(VAR)        do{ persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc, !validating);  }while(0)
-  #define EEPROM_READ_ALWAYS(VAR) do{ persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc);               }while(0)
   #define EEPROM_ASSERT(TST,ERR)  do{ if (!(TST)) { SERIAL_ERROR_MSG(ERR); eeprom_error = true; } }while(0)
 
   #if ENABLED(DEBUG_EEPROM_READWRITE)
@@ -589,6 +607,8 @@ void MarlinSettings::postprocess() {
   const char version[4] = EEPROM_VERSION;
 
   bool MarlinSettings::eeprom_error, MarlinSettings::validating;
+  int MarlinSettings::eeprom_index;
+  uint16_t MarlinSettings::working_crc;
 
   bool MarlinSettings::size_error(const uint16_t size) {
     if (size != datasize()) {
@@ -603,14 +623,11 @@ void MarlinSettings::postprocess() {
    */
   extern uint16_t Flsun_language;//新增
   extern millis_t total_time;//新增
-  extern uint8_t sd_filename_size;//新增
   bool MarlinSettings::save() {
     float dummyf = 0;
     char ver[4] = "ERR";
 
-    uint16_t working_crc = 0;
-
-    EEPROM_START();
+    if (!EEPROM_START(EEPROM_OFFSET)) return false;
 
     eeprom_error = false;
 
@@ -620,8 +637,7 @@ void MarlinSettings::postprocess() {
     EEPROM_SKIP(working_crc); // Skip the checksum slot
 
     working_crc = 0; // clear before first "real data"
-    persistentStore.write_data(960, (uint8_t*)&Flsun_language, sizeof(Flsun_language));//新增，在eeprom960位置写入语言数据
-    persistentStore.write_data(970, (uint8_t*)&total_time, sizeof(total_time));//新增，在eeprom970位置写入总打印时间
+
     _FIELD_TEST(esteppers);
 
     const uint8_t esteppers = COUNT(planner.settings.axis_steps_per_mm) - XYZ;
@@ -839,7 +855,7 @@ void MarlinSettings::postprocess() {
         EEPROM_WRITE(delta_endstop_adj);         // 3 floats
         EEPROM_WRITE(delta_radius);              // 1 float
         EEPROM_WRITE(delta_diagonal_rod);        // 1 float
-        EEPROM_WRITE(delta_segments_per_second); // 1 float
+        EEPROM_WRITE(delta_segments_per_second);       // 1 float
         EEPROM_WRITE(delta_tower_angle_trim);    // 3 floats
         EEPROM_WRITE(delta_diagonal_rod_trim);   // 3 floats
 
@@ -928,6 +944,25 @@ void MarlinSettings::postprocess() {
         #endif
       };
       EEPROM_WRITE(bed_pid);
+    }
+
+    //
+    // PIDTEMPCHAMBER
+    //
+    {
+      _FIELD_TEST(chamberPID);
+
+      const PID_t chamber_pid = {
+        #if DISABLED(PIDTEMPCHAMBER)
+          NAN, NAN, NAN
+        #else
+          // Store the unscaled PID values
+          thermalManager.temp_chamber.pid.Kp,
+          unscalePID_i(thermalManager.temp_chamber.pid.Ki),
+          unscalePID_d(thermalManager.temp_chamber.pid.Kd)
+        #endif
+      };
+      EEPROM_WRITE(chamber_pid);
     }
 
     //
@@ -1390,11 +1425,29 @@ void MarlinSettings::postprocess() {
     #endif
 
     //
+    // MKS UI controller
+    //
+    #if ENABLED(DGUS_LCD_UI_MKS)
+      EEPROM_WRITE(mks_language_index);
+      EEPROM_WRITE(mks_corner_offsets);
+      EEPROM_WRITE(mks_park_pos);
+      EEPROM_WRITE(mks_min_extrusion_temp);
+    #endif
+
+    //
     // Selected LCD language
     //
     #if HAS_MULTI_LANGUAGE
       EEPROM_WRITE(ui.language);
     #endif
+
+//FLSun Special Parameters
+    SERIAL_ECHO_MSG("settings: 1401 Flsun language is :", Flsun_language, "\"");
+    _FIELD_TEST(Flsun_language);
+    EEPROM_WRITE(Flsun_language);
+    SERIAL_ECHO_MSG("settings: 1402 Total time is :", total_time, "\"");
+    _FIELD_TEST(total_time);
+    EEPROM_WRITE(total_time);
 
     //
     // Report final CRC and Data Size
@@ -1436,9 +1489,7 @@ void MarlinSettings::postprocess() {
    * M501 - Retrieve Configuration
    */
   bool MarlinSettings::_load() {
-    uint16_t working_crc = 0;
-
-    EEPROM_START();
+    if (!EEPROM_START(EEPROM_OFFSET)) return false;
 
     char stored_ver[4];
     EEPROM_READ_ALWAYS(stored_ver);
@@ -1460,64 +1511,7 @@ void MarlinSettings::postprocess() {
     else {
       float dummyf = 0;
       working_crc = 0;  // Init to 0. Accumulated by EEPROM_READ
-      persistentStore.read_data(960, (uint8_t*)&Flsun_language, sizeof(Flsun_language));//新增
-      persistentStore.read_data(970, (uint8_t*)&total_time, sizeof(total_time));//新增，在eeprom970位置写入总打印时间
-      int eeprom_pos_duandian = 900;//新增
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.valid_head, sizeof(recovery.info.valid_head));
-    eeprom_pos_duandian += sizeof(recovery.info.valid_head);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.valid_foot, sizeof(recovery.info.valid_foot));
-    eeprom_pos_duandian += sizeof(recovery.info.valid_foot);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.current_position.x, sizeof(recovery.info.current_position.x));
-    eeprom_pos_duandian += sizeof(recovery.info.current_position.x);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.current_position.y, sizeof(recovery.info.current_position.y));
-    eeprom_pos_duandian += sizeof(recovery.info.current_position.y);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.current_position.z, sizeof(recovery.info.current_position.z));
-    eeprom_pos_duandian += sizeof(recovery.info.current_position.z);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.current_position.e, sizeof(recovery.info.current_position.e));
-    eeprom_pos_duandian += sizeof(recovery.info.current_position.e);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.feedrate, sizeof(recovery.info.feedrate));
-    eeprom_pos_duandian += sizeof(recovery.info.feedrate);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.zraise, sizeof(recovery.info.zraise));
-    eeprom_pos_duandian += sizeof(recovery.info.zraise);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.position_shift.x, sizeof(recovery.info.position_shift.x));
-    eeprom_pos_duandian += sizeof(recovery.info.position_shift.x);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.position_shift.y, sizeof(recovery.info.position_shift.y));
-    eeprom_pos_duandian += sizeof(recovery.info.position_shift.y);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.position_shift.z, sizeof(recovery.info.position_shift.z));
-    eeprom_pos_duandian += sizeof(recovery.info.position_shift.z);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.volumetric_enabled, sizeof(recovery.info.volumetric_enabled));
-    eeprom_pos_duandian += sizeof(recovery.info.volumetric_enabled);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.target_temperature[0], sizeof(recovery.info.target_temperature[0]));
-    eeprom_pos_duandian += sizeof(recovery.info.target_temperature[0]);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.target_temperature_bed, sizeof(recovery.info.target_temperature_bed));
-    eeprom_pos_duandian += sizeof(recovery.info.target_temperature_bed);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.fan_speed[0], sizeof(recovery.info.fan_speed[0]));
-    eeprom_pos_duandian += sizeof(recovery.info.fan_speed[0]);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.flag.leveling, sizeof(recovery.info.flag.leveling));
-    eeprom_pos_duandian += sizeof(bool);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.fade, sizeof(recovery.info.fade));
-    eeprom_pos_duandian += sizeof(recovery.info.fade);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.print_job_elapsed, sizeof(recovery.info.print_job_elapsed));
-    eeprom_pos_duandian += sizeof(recovery.info.print_job_elapsed);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.axis_relative, sizeof(recovery.info.axis_relative));
-    eeprom_pos_duandian += sizeof(recovery.info.axis_relative);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.flag.dryrun, sizeof(recovery.info.flag.dryrun));
-    eeprom_pos_duandian += sizeof(bool);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.flag.allow_cold_extrusion, sizeof(recovery.info.flag.allow_cold_extrusion));
-    eeprom_pos_duandian += sizeof(bool);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.sdpos, sizeof(recovery.info.sdpos));
-    eeprom_pos_duandian += sizeof(recovery.info.sdpos);
-    persistentStore.read_data(eeprom_pos_duandian, (uint8_t*)&recovery.info.flag_duandian, sizeof(recovery.info.flag_duandian));
-    eeprom_pos_duandian += sizeof(recovery.info.flag_duandian);
-    persistentStore.read_data(983, (uint8_t*)&sd_filename_size, sizeof(sd_filename_size));
-    for(int i = 0;i < sd_filename_size;i++)
-    {
-      persistentStore.read_data(985 + i, (uint8_t*)&recovery.info.sd_filename[i], sizeof(recovery.info.sd_filename[i]));
-    }//新增
-      MSerial.print("Flsun language is :");
-      MSerial.println(Flsun_language);
-      MSerial.print("total time is :");
-      MSerial.println(total_time);
+
       _FIELD_TEST(esteppers);
 
       // Number of esteppers may change
@@ -1533,10 +1527,10 @@ void MarlinSettings::postprocess() {
         uint32_t tmp1[XYZ + esteppers];
         float tmp2[XYZ + esteppers];
         feedRate_t tmp3[XYZ + esteppers];
-        EEPROM_READ(tmp1);                         // max_acceleration_mm_per_s2
+        EEPROM_READ((uint8_t *)tmp1, sizeof(tmp1)); // max_acceleration_mm_per_s2
         EEPROM_READ(planner.settings.min_segment_time_us);
-        EEPROM_READ(tmp2);                         // axis_steps_per_mm
-        EEPROM_READ(tmp3);                         // max_feedrate_mm_s
+        EEPROM_READ((uint8_t *)tmp2, sizeof(tmp2)); // axis_steps_per_mm
+        EEPROM_READ((uint8_t *)tmp3, sizeof(tmp3)); // max_feedrate_mm_s
 
         if (!validating) LOOP_XYZE_N(i) {
           const bool in = (i < esteppers + XYZ);
@@ -1626,7 +1620,7 @@ void MarlinSettings::postprocess() {
 
         #if ENABLED(MESH_BED_LEVELING)
           if (!validating) mbl.z_offset = dummyf;
-          if (mesh_num_x == GRID_MAX_POINTS_X && mesh_num_y == GRID_MAX_POINTS_Y) {
+          if (mesh_num_x == (GRID_MAX_POINTS_X) && mesh_num_y == (GRID_MAX_POINTS_Y)) {
             // EEPROM data fits the current mesh
             EEPROM_READ(mbl.z_values);
           }
@@ -1673,7 +1667,7 @@ void MarlinSettings::postprocess() {
         EEPROM_READ_ALWAYS(grid_max_x);                // 1 byte
         EEPROM_READ_ALWAYS(grid_max_y);                // 1 byte
         #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-          if (grid_max_x == GRID_MAX_POINTS_X && grid_max_y == GRID_MAX_POINTS_Y) {
+          if (grid_max_x == (GRID_MAX_POINTS_X) && grid_max_y == (GRID_MAX_POINTS_Y)) {
             if (!validating) set_bed_leveling_enabled(false);
             EEPROM_READ(bilinear_grid_spacing);        // 2 ints
             EEPROM_READ(bilinear_start);               // 2 ints
@@ -1758,7 +1752,7 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(delta_endstop_adj);         // 3 floats
           EEPROM_READ(delta_radius);              // 1 float
           EEPROM_READ(delta_diagonal_rod);        // 1 float
-          EEPROM_READ(delta_segments_per_second); // 1 float
+          EEPROM_READ(delta_segments_per_second);       // 1 float
           EEPROM_READ(delta_tower_angle_trim);    // 3 floats
           EEPROM_READ(delta_diagonal_rod_trim);   // 3 floats
 
@@ -1844,6 +1838,22 @@ void MarlinSettings::postprocess() {
             thermalManager.temp_bed.pid.Kp = pid.Kp;
             thermalManager.temp_bed.pid.Ki = scalePID_i(pid.Ki);
             thermalManager.temp_bed.pid.Kd = scalePID_d(pid.Kd);
+          }
+        #endif
+      }
+
+      //
+      // Heated Chamber PID
+      //
+      {
+        PID_t pid;
+        EEPROM_READ(pid);
+        #if ENABLED(PIDTEMPCHAMBER)
+          if (!validating && !isnan(pid.Kp)) {
+            // Scale PID values since EEPROM values are unscaled
+            thermalManager.temp_chamber.pid.Kp = pid.Kp;
+            thermalManager.temp_chamber.pid.Ki = scalePID_i(pid.Ki);
+            thermalManager.temp_chamber.pid.Kd = scalePID_d(pid.Kd);
           }
         #endif
       }
@@ -2333,6 +2343,17 @@ void MarlinSettings::postprocess() {
       #endif
 
       //
+      // MKS UI controller
+      //
+      #if ENABLED(DGUS_LCD_UI_MKS)
+        _FIELD_TEST(mks_language_index);
+        EEPROM_READ(mks_language_index);
+        EEPROM_READ(mks_corner_offsets);
+        EEPROM_READ(mks_park_pos);
+        EEPROM_READ(mks_min_extrusion_temp);
+      #endif
+
+      //
       // Selected LCD language
       //
       #if HAS_MULTI_LANGUAGE
@@ -2344,13 +2365,26 @@ void MarlinSettings::postprocess() {
       }
       #endif
 
+      _FIELD_TEST(Flsun_language);
+      EEPROM_READ(Flsun_language);
+      setFLSunLanguage(Flsun_language);
+      _FIELD_TEST(total_time);
+      EEPROM_READ(total_time);
+      setFLSunHours(total_time);
+      
+      
+      MSerial.print("Flsun language is :");
+      MSerial.println(Flsun_language);
+      MSerial.print("total time is :");
+      MSerial.println(total_time);
+
       //
       // Validate Final Size and CRC
       //
       eeprom_error = size_error(eeprom_index - (EEPROM_OFFSET));
       if (eeprom_error) {
         DEBUG_ECHO_START();
-        DEBUG_ECHOLNPAIR("Index: ", int(eeprom_index - (EEPROM_OFFSET)), " Size: ", datasize());
+        DEBUG_ECHOLNPAIR("Index: ", eeprom_index - (EEPROM_OFFSET), " Size: ", datasize());
         IF_DISABLED(EEPROM_AUTO_INIT, ui.eeprom_alert_index());
       }
       else if (working_crc != stored_crc) {
@@ -2774,25 +2808,20 @@ void MarlinSettings::reset() {
   // Preheat parameters
   //
   #if PREHEAT_COUNT
+    #define _PITEM(N,T) PREHEAT_##N##_##T,
     #if HAS_HOTEND
-      constexpr uint16_t hpre[] = ARRAY_N(PREHEAT_COUNT, PREHEAT_1_TEMP_HOTEND, PREHEAT_2_TEMP_HOTEND, PREHEAT_3_TEMP_HOTEND, PREHEAT_4_TEMP_HOTEND, PREHEAT_5_TEMP_HOTEND);
+      constexpr uint16_t hpre[] = { REPEAT2_S(1, INCREMENT(PREHEAT_COUNT), _PITEM, TEMP_HOTEND) };
     #endif
     #if HAS_HEATED_BED
-      constexpr uint16_t bpre[] = ARRAY_N(PREHEAT_COUNT, PREHEAT_1_TEMP_BED, PREHEAT_2_TEMP_BED, PREHEAT_3_TEMP_BED, PREHEAT_4_TEMP_BED, PREHEAT_5_TEMP_BED);
+      constexpr uint16_t bpre[] = { REPEAT2_S(1, INCREMENT(PREHEAT_COUNT), _PITEM, TEMP_BED) };
     #endif
     #if HAS_FAN
-      constexpr uint8_t fpre[] = ARRAY_N(PREHEAT_COUNT, PREHEAT_1_FAN_SPEED, PREHEAT_2_FAN_SPEED, PREHEAT_3_FAN_SPEED, PREHEAT_4_FAN_SPEED, PREHEAT_5_FAN_SPEED);
+      constexpr uint8_t fpre[] = { REPEAT2_S(1, INCREMENT(PREHEAT_COUNT), _PITEM, FAN_SPEED) };
     #endif
     LOOP_L_N(i, PREHEAT_COUNT) {
-      #if HAS_HOTEND
-        ui.material_preset[i].hotend_temp = hpre[i];
-      #endif
-      #if HAS_HEATED_BED
-        ui.material_preset[i].bed_temp = bpre[i];
-      #endif
-      #if HAS_FAN
-        ui.material_preset[i].fan_speed = fpre[i];
-      #endif
+      TERN_(HAS_HOTEND,     ui.material_preset[i].hotend_temp = hpre[i]);
+      TERN_(HAS_HEATED_BED, ui.material_preset[i].bed_temp = bpre[i]);
+      TERN_(HAS_FAN,        ui.material_preset[i].fan_speed = fpre[i]);
     }
   #endif
 
@@ -2870,6 +2899,16 @@ void MarlinSettings::reset() {
     thermalManager.temp_bed.pid.Kp = DEFAULT_bedKp;
     thermalManager.temp_bed.pid.Ki = scalePID_i(DEFAULT_bedKi);
     thermalManager.temp_bed.pid.Kd = scalePID_d(DEFAULT_bedKd);
+  #endif
+
+  //
+  // Heated Chamber PID
+  //
+
+  #if ENABLED(PIDTEMPCHAMBER)
+    thermalManager.temp_chamber.pid.Kp = DEFAULT_chamberKp;
+    thermalManager.temp_chamber.pid.Ki = scalePID_i(DEFAULT_chamberKi);
+    thermalManager.temp_chamber.pid.Kd = scalePID_d(DEFAULT_chamberKd);
   #endif
 
   //
@@ -2987,6 +3026,11 @@ void MarlinSettings::reset() {
     #endif
   #endif
 
+  //
+  // MKS UI controller
+  //
+  TERN_(DGUS_LCD_UI_MKS, MKS_reset_settings());
+
   postprocess();
 
   DEBUG_ECHO_START();
@@ -3001,13 +3045,13 @@ void MarlinSettings::reset() {
     if (!repl) {
       SERIAL_ECHO_START();
       SERIAL_ECHOPGM("; ");
-      serialprintPGM(pstr);
+      SERIAL_ECHOPGM_P(pstr);
       if (eol) SERIAL_EOL();
     }
   }
 
   #define CONFIG_ECHO_START()       do{ if (!forReplay) SERIAL_ECHO_START(); }while(0)
-  #define CONFIG_ECHO_MSG(STR)      do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPGM(STR); }while(0)
+  #define CONFIG_ECHO_MSG(V...)     do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPAIR(V); }while(0)
   #define CONFIG_ECHO_HEADING(STR)  config_heading(forReplay, PSTR(STR))
 
   #if HAS_TRINAMIC_CONFIG
@@ -3018,7 +3062,7 @@ void MarlinSettings::reset() {
         SERIAL_ECHOPGM("  M569 S1");
         if (etc) {
           SERIAL_CHAR(' ');
-          serialprintPGM(etc);
+          SERIAL_ECHOPGM_P(etc);
         }
         if (newLine) SERIAL_EOL();
       }
@@ -3036,7 +3080,7 @@ void MarlinSettings::reset() {
   #endif
 
   inline void say_units(const bool colon) {
-    serialprintPGM(
+    SERIAL_ECHOPGM_P(
       #if ENABLED(INCH_MODE_SUPPORT)
         parser.linear_unit_factor != 1.0 ? PSTR(" (in)") :
       #endif
@@ -3077,7 +3121,7 @@ void MarlinSettings::reset() {
         SERIAL_ECHOPGM("  M149 ");
         SERIAL_CHAR(parser.temp_units_code());
         SERIAL_ECHOPGM(" ; Units in ");
-        serialprintPGM(parser.temp_units_name());
+        SERIAL_ECHOPGM_P(parser.temp_units_name());
       #else
         SERIAL_ECHOLNPGM("  M149 C ; Units in Celsius");
       #endif
@@ -3100,26 +3144,24 @@ void MarlinSettings::reset() {
       }
 
       #if EXTRUDERS == 1
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR("  M200 S", int(parser.volumetric_enabled)
-                              , " D", LINEAR_UNIT(planner.filament_size[0])
-                              #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-                                , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[0])
-                              #endif
-                         );
+        CONFIG_ECHO_MSG("  M200 S", parser.volumetric_enabled
+                            , " D", LINEAR_UNIT(planner.filament_size[0])
+                            #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
+                              , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[0])
+                            #endif
+                       );
       #else
         LOOP_L_N(i, EXTRUDERS) {
-          CONFIG_ECHO_START();
-          SERIAL_ECHOLNPAIR("  M200 T", int(i)
-                                , " D", LINEAR_UNIT(planner.filament_size[i])
-                                #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-                                  , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[i])
-                                #endif
-                           );
+          CONFIG_ECHO_MSG("  M200 T", i
+                              , " D", LINEAR_UNIT(planner.filament_size[i])
+                              #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
+                                , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[i])
+                              #endif
+                         );
         }
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR("  M200 S", int(parser.volumetric_enabled));
+        CONFIG_ECHO_MSG("  M200 S", parser.volumetric_enabled);
       #endif
+
     #endif // EXTRUDERS && !NO_VOLUMETRICS
 
     CONFIG_ECHO_HEADING("Steps per unit:");
@@ -3139,7 +3181,7 @@ void MarlinSettings::reset() {
       LOOP_L_N(i, E_STEPPERS) {
         CONFIG_ECHO_START();
         SERIAL_ECHOLNPAIR_P(
-            PSTR("  M203 T"), (int)i
+            PSTR("  M203 T"), i
           , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)])
         );
       }
@@ -3159,7 +3201,7 @@ void MarlinSettings::reset() {
       LOOP_L_N(i, E_STEPPERS) {
         CONFIG_ECHO_START();
         SERIAL_ECHOLNPAIR_P(
-            PSTR("  M201 T"), (int)i
+            PSTR("  M201 T"), i
           , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)])
         );
       }
@@ -3221,7 +3263,7 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_START();
       LOOP_S_L_N(e, 1, HOTENDS) {
         SERIAL_ECHOPAIR_P(
-          PSTR("  M218 T"), (int)e,
+          PSTR("  M218 T"), e,
           SP_X_STR, LINEAR_UNIT(hotend_offset[e].x),
           SP_Y_STR, LINEAR_UNIT(hotend_offset[e].y)
         );
@@ -3255,7 +3297,7 @@ void MarlinSettings::reset() {
 
       CONFIG_ECHO_START();
       SERIAL_ECHOLNPAIR_P(
-        PSTR("  M420 S"), planner.leveling_active ? 1 : 0
+        PSTR("  M420 S"), planner.leveling_active
         #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
           , SP_Z_STR, LINEAR_UNIT(planner.z_fade_height)
         #endif
@@ -3267,12 +3309,12 @@ void MarlinSettings::reset() {
           LOOP_L_N(py, GRID_MAX_POINTS_Y) {
             LOOP_L_N(px, GRID_MAX_POINTS_X) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P(PSTR("  G29 S3 I"), (int)px, PSTR(" J"), (int)py);
+              SERIAL_ECHOPAIR("  G29 S3 I", px, " J", py);
               SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(mbl.z_values[px][py]), 5);
             }
           }
           CONFIG_ECHO_START();
-          SERIAL_ECHOLNPAIR_F_P(PSTR("  G29 S4 Z"), LINEAR_UNIT(mbl.z_offset), 5);
+          SERIAL_ECHOLNPAIR_F("  G29 S4 Z", LINEAR_UNIT(mbl.z_offset), 5);
         }
 
       #elif ENABLED(AUTO_BED_LEVELING_UBL)
@@ -3296,7 +3338,7 @@ void MarlinSettings::reset() {
           LOOP_L_N(py, GRID_MAX_POINTS_Y) {
             LOOP_L_N(px, GRID_MAX_POINTS_X) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR("  G29 W I", (int)px, " J", (int)py);
+              SERIAL_ECHOPAIR("  G29 W I", px, " J", py);
               SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(z_values[px][py]), 5);
             }
           }
@@ -3321,8 +3363,7 @@ void MarlinSettings::reset() {
           #elif ENABLED(BLTOUCH) || (HAS_Z_SERVO_PROBE && defined(Z_SERVO_ANGLES))
             case Z_PROBE_SERVO_NR:
           #endif
-            CONFIG_ECHO_START();
-            SERIAL_ECHOLNPAIR("  M281 P", int(i), " L", servo_angles[i][0], " U", servo_angles[i][1]);
+            CONFIG_ECHO_MSG("  M281 P", i, " L", servo_angles[i][0], " U", servo_angles[i][1]);
           default: break;
         }
       }
@@ -3334,7 +3375,7 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_HEADING("SCARA settings: S<seg-per-sec> P<theta-psi-offset> T<theta-offset>");
       CONFIG_ECHO_START();
       SERIAL_ECHOLNPAIR_P(
-          PSTR("  M665 S"), delta_segments_per_second
+          PSTR("  M665 S"), segments_per_second
         , SP_P_STR, scara_home_offset.a
         , SP_T_STR, scara_home_offset.b
         , SP_Z_STR, LINEAR_UNIT(scara_home_offset.z)
@@ -3398,12 +3439,12 @@ void MarlinSettings::reset() {
       LOOP_L_N(i, PREHEAT_COUNT) {
         CONFIG_ECHO_START();
         SERIAL_ECHOLNPAIR_P(
-          PSTR("  M145 S"), (int)i
+          PSTR("  M145 S"), i
           #if HAS_HOTEND
-            , PSTR(" H"), TEMP_UNIT(ui.material_preset[i].hotend_temp)
+            , PSTR(" H"), ui.material_preset[i].hotend_temp
           #endif
           #if HAS_HEATED_BED
-            , SP_B_STR, TEMP_UNIT(ui.material_preset[i].bed_temp)
+            , SP_B_STR, ui.material_preset[i].bed_temp
           #endif
           #if HAS_FAN
             , PSTR(" F"), ui.material_preset[i].fan_speed
@@ -3443,15 +3484,23 @@ void MarlinSettings::reset() {
       #endif // PIDTEMP
 
       #if ENABLED(PIDTEMPBED)
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR(
+        CONFIG_ECHO_MSG(
             "  M304 P", thermalManager.temp_bed.pid.Kp
           , " I", unscalePID_i(thermalManager.temp_bed.pid.Ki)
           , " D", unscalePID_d(thermalManager.temp_bed.pid.Kd)
         );
       #endif
 
-    #endif // PIDTEMP || PIDTEMPBED
+      #if ENABLED(PIDTEMPCHAMBER)
+        CONFIG_ECHO_START();
+        SERIAL_ECHOLNPAIR(
+            "  M309 P", thermalManager.temp_chamber.pid.Kp
+          , " I", unscalePID_i(thermalManager.temp_chamber.pid.Ki)
+          , " D", unscalePID_d(thermalManager.temp_chamber.pid.Kd)
+        );
+      #endif
+
+    #endif // PIDTEMP || PIDTEMPBED || PIDTEMPCHAMBER
 
     #if HAS_USER_THERMISTORS
       CONFIG_ECHO_HEADING("User thermistors:");
@@ -3461,46 +3510,21 @@ void MarlinSettings::reset() {
 
     #if HAS_LCD_CONTRAST
       CONFIG_ECHO_HEADING("LCD Contrast:");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR("  M250 C", ui.contrast);
+      CONFIG_ECHO_MSG("  M250 C", ui.contrast);
     #endif
 
     TERN_(CONTROLLER_FAN_EDITABLE, M710_report(forReplay));
 
     #if ENABLED(POWER_LOSS_RECOVERY)
       CONFIG_ECHO_HEADING("Power-Loss Recovery:");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR("  M413 S", int(recovery.enabled));
+      CONFIG_ECHO_MSG("  M413 S", recovery.enabled);
     #endif
 
     #if ENABLED(FWRETRACT)
-
-      CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-          PSTR("  M207 S"), LINEAR_UNIT(fwretract.settings.retract_length)
-        , PSTR(" W"), LINEAR_UNIT(fwretract.settings.swap_retract_length)
-        , PSTR(" F"), LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_feedrate_mm_s))
-        , SP_Z_STR, LINEAR_UNIT(fwretract.settings.retract_zraise)
-      );
-
-      CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR(
-          "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_extra)
-        , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_extra)
-        , " F", LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_recover_feedrate_mm_s))
-      );
-
-      #if ENABLED(FWRETRACT_AUTORETRACT)
-
-        CONFIG_ECHO_HEADING("Auto-Retract: S=0 to disable, 1 to interpret E-only moves as retract/recover");
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR("  M209 S", fwretract.autoretract_enabled ? 1 : 0);
-
-      #endif // FWRETRACT_AUTORETRACT
-
-    #endif // FWRETRACT
+      fwretract.M207_report(forReplay);
+      fwretract.M208_report(forReplay);
+      TERN_(FWRETRACT_AUTORETRACT, fwretract.M209_report(forReplay));
+    #endif
 
     /**
      * Probe Offset
@@ -3841,13 +3865,10 @@ void MarlinSettings::reset() {
     #if ENABLED(LIN_ADVANCE)
       CONFIG_ECHO_HEADING("Linear Advance:");
       #if EXTRUDERS < 2
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR("  M900 K", planner.extruder_advance_K[0]);
+        CONFIG_ECHO_MSG("  M900 K", planner.extruder_advance_K[0]);
       #else
-        LOOP_L_N(i, EXTRUDERS) {
-          CONFIG_ECHO_START();
-          SERIAL_ECHOLNPAIR("  M900 T", int(i), " K", planner.extruder_advance_K[i]);
-        }
+        LOOP_L_N(i, EXTRUDERS)
+          CONFIG_ECHO_MSG("  M900 T", i, " K", planner.extruder_advance_K[i]);
       #endif
     #endif
 
@@ -3912,9 +3933,8 @@ void MarlinSettings::reset() {
 
     #if HAS_FILAMENT_SENSOR
       CONFIG_ECHO_HEADING("Filament runout sensor:");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR(
-        "  M412 S", int(runout.enabled)
+      CONFIG_ECHO_MSG(
+        "  M412 S", runout.enabled
         #if HAS_FILAMENT_RUNOUT_DISTANCE
           , " D", LINEAR_UNIT(runout.runout_distance())
         #endif
@@ -3932,13 +3952,10 @@ void MarlinSettings::reset() {
 
     #if HAS_MULTI_LANGUAGE
       CONFIG_ECHO_HEADING("UI Language:");
-      SERIAL_ECHO_MSG("  M414 S", int(ui.language));
+      SERIAL_ECHO_MSG("  M414 S", ui.language);
     #endif
   }
 
 #endif // !DISABLE_M503
-float mesh_point(int I,int J)//新增
-{
-  return z_values[I][J];
-}
+
 #pragma pack(pop)

--- a/Marlin/src/module/settings.h
+++ b/Marlin/src/module/settings.h
@@ -76,12 +76,15 @@ class MarlinSettings {
         //static void delete_mesh();    // necessary if we have a MAT
         //static void defrag_meshes();  // "
       #endif
-    #else
+
+    #else // !EEPROM_SETTINGS
+
       FORCE_INLINE
       static bool load() { reset(); report(); return true; }
       FORCE_INLINE
       static void first_load() { (void)load(); }
-    #endif
+
+    #endif // !EEPROM_SETTINGS
 
     #if DISABLED(DISABLE_M503)
       static void report(const bool forReplay=false);
@@ -105,8 +108,42 @@ class MarlinSettings {
 
       static bool _load();
       static bool size_error(const uint16_t size);
-    #endif
+
+      static int eeprom_index;
+      static uint16_t working_crc;
+
+      static bool EEPROM_START(int eeprom_offset) {
+        if (!persistentStore.access_start()) { SERIAL_ECHO_MSG("No EEPROM."); return false; }
+        eeprom_index = eeprom_offset;
+        working_crc = 0;
+        return true;
+      }
+
+      static void EEPROM_FINISH(void) { persistentStore.access_finish(); }
+
+      template<typename T>
+      static void EEPROM_SKIP(const T &VAR) { eeprom_index += sizeof(VAR); }
+
+      template<typename T>
+      static void EEPROM_WRITE(const T &VAR) {
+        persistentStore.write_data(eeprom_index, (const uint8_t *) &VAR, sizeof(VAR), &working_crc);
+      }
+
+      template<typename T>
+      static void EEPROM_READ(T &VAR) {
+        persistentStore.read_data(eeprom_index, (uint8_t *) &VAR, sizeof(VAR), &working_crc, !validating);
+      }
+
+      static void EEPROM_READ(uint8_t *VAR, size_t sizeof_VAR) {
+        persistentStore.read_data(eeprom_index, VAR, sizeof_VAR, &working_crc, !validating);
+      }
+
+      template<typename T>
+      static void EEPROM_READ_ALWAYS(T &VAR) {
+        persistentStore.read_data(eeprom_index, (uint8_t *) &VAR, sizeof(VAR), &working_crc);
+      }
+
+    #endif // EEPROM_SETTINGS
 };
 
 extern MarlinSettings settings;
-float mesh_point(int I,int J);//新增

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -336,10 +336,6 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
 
 // private:
 
-#if EARLY_WATCHDOG
-  bool Temperature::inited = false;
-#endif
-
 #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
   uint16_t Temperature::redundant_temperature_raw = 0;
   float Temperature::redundant_temperature = 0.0;
@@ -1089,12 +1085,7 @@ void Temperature::min_temp_error(const heater_id_t heater_id) {
  *  - Update the heated bed PID output value
  */
 void Temperature::manage_heater() {
-
-  #if EARLY_WATCHDOG
-    // If thermal manager is still not running, make sure to at least reset the watchdog!
-    if (!inited) return watchdog_refresh();
-  #endif
-
+  if (marlin_state == MF_INITIALIZING) return watchdog_refresh(); // If Marlin isn't started, at least reset the watchdog!
   #if ENABLED(EMERGENCY_PARSER)
     if (emergency_parser.killed_by_M112) kill(M112_KILL_STR, nullptr, true);
 
@@ -1744,12 +1735,6 @@ void Temperature::init() {
   TERN_(MAX6675_0_IS_MAX31865, max31865_0.begin(MAX31865_2WIRE)); // MAX31865_2WIRE, MAX31865_3WIRE, MAX31865_4WIRE
   TERN_(MAX6675_1_IS_MAX31865, max31865_1.begin(MAX31865_2WIRE));
 
-  #if EARLY_WATCHDOG
-    // Flag that the thermalManager should be running
-    if (inited) return;
-    inited = true;
-  #endif
-
   #if MB(RUMBA)
     // Disable RUMBA JTAG in case the thermocouple extension is plugged on top of JTAG connector
     #define _AD(N) (HEATER_##N##_USES_AD595 || HEATER_##N##_USES_AD8495)
@@ -1935,7 +1920,7 @@ void Temperature::init() {
   #endif
 
   // Wait for temperature measurement to settle
-  delay(250);
+  //delay(250);
 
   #if HAS_HOTEND
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -384,8 +384,6 @@ class Temperature {
 
   private:
 
-    TERN_(EARLY_WATCHDOG, static bool inited);   // If temperature controller is running
-
     static volatile bool raw_temps_ready;
 
     TERN_(WATCH_HOTENDS, static hotend_watch_t watch_hotend[HOTENDS]);

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-If you like my job, you can support me by paying me a 🍺 or a ☕. Thanks 🙂
+If you like my job, you can support my :smiley_cat: by paying me a :canned_food: or a :sushi:. Thanks 🙂
 
- [ ![Download](https://user-images.githubusercontent.com/12702322/115148445-e5a40100-a05f-11eb-8552-c1f5d4355987.png) ](https://www.paypal.me/CyrilGuislain)
+ [ ![Download](https://user-images.githubusercontent.com/12702322/115148445-e5a40100-a05f-11eb-8552-c1f5d4355987.png) ](https://paypal.me/milothecat2)
 
 <img align="left" width=600 src="https://user-images.githubusercontent.com/12702322/129816796-0f8a7844-0c04-45f5-aee3-321125e5ebe4.jpg" />
 
@@ -14,6 +14,7 @@ If you like my job, you can support me by paying me a 🍺 or a ☕. Thanks 🙂
 
 ## Main features:
 
+**- EEPROM Storage should now work and persist (no more missing text, language resetting, or loss of Z0 and other calibrations)**
 - MKS Robin Nano V3 motherboard support
 - TMC2209 / TMC2226 UART drivers support
 - Nozzle & Bed PID support

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-If you like my job, you can support my :smiley_cat: by paying me a :canned_food: or a :sushi:. Thanks 🙂
+If you like my job, you can support me by paying me a 🍺 or a ☕. Thanks 🙂
 
- [ ![Download](https://user-images.githubusercontent.com/12702322/115148445-e5a40100-a05f-11eb-8552-c1f5d4355987.png) ](https://paypal.me/milothecat2)
+ [ ![Download](https://user-images.githubusercontent.com/12702322/115148445-e5a40100-a05f-11eb-8552-c1f5d4355987.png) ](https://www.paypal.me/CyrilGuislain)
 
 <img align="left" width=600 src="https://user-images.githubusercontent.com/12702322/129816796-0f8a7844-0c04-45f5-aee3-321125e5ebe4.jpg" />
 
@@ -14,7 +14,6 @@ If you like my job, you can support my :smiley_cat: by paying me a :canned_food:
 
 ## Main features:
 
-**- EEPROM Storage should now work and persist (no more missing text, language resetting, or loss of Z0 and other calibrations)**
 - MKS Robin Nano V3 motherboard support
 - TMC2209 / TMC2226 UART drivers support
 - Nozzle & Bed PID support

--- a/buildroot/share/PlatformIO/variants/MARLIN_F4x7Vx/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F4x7Vx/variant.h
@@ -143,8 +143,12 @@ extern "C" {
 #define PIN_SPI_SCK             PA5
 
 // I2C definitions
-#define PIN_WIRE_SDA            PB9
-#define PIN_WIRE_SCL            PB8
+#ifndef PIN_WIRE_SDA
+  #define PIN_WIRE_SDA          PB9
+#endif
+#ifndef PIN_WIRE_SCL
+  #define PIN_WIRE_SCL          PB8
+#endif
 
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin


### PR DESCRIPTION
This PR is not ready for prime time yet, but its mostly there. I wanted to share the changes with your for your review. I am not a Marlin expert and I am sure you know more than I do about it. There are also some files like the readme that are intentioned for my fork and I need to prune them from this request.

I would also like to test it some more on my printer (have been testing only for a couple of days since I finished all the fixes) but so far its working great.

I think I got all the files I changed in this PR but if you get a build error or anything let me know the details and I will see if I left anything out.

### Description

So as I have also now commonly seen complained about on the Facebook group, I too was suffering the issue where all configurations would clear upon power cycling the printer, and text would also disappear. This could be solved by going to Language and selecting "English", and then resetting all my calibrations but that's foolish and should not be required.

So I made a large mistake, and started poking around the source code. After adding much logging and probing all of the settings logic I discovered a myriad of issues.

1. In settings.cpp FLSun did not correctly add their custom values to the EEPROM definition. Instead they opted to very smartly just write them to hardcoded EEPROM locations like so

```
persistentStore.write_data(960, (uint8_t*)&Flsun_language, sizeof(Flsun_language));//新增，在eeprom960位置写入语言数据
persistentStore.write_data(970, (uint8_t*)&total_time, sizeof(total_time));//新增，在eeprom970位置写入总打印时间
```

If one peruses the rest of settings.cpp you will find that all other original Marlin settings are located in EEPROM based on relative size and position and in reference to the "SettingsDataStruct". FLSun did not update this struct, and instead short-circuited the logic to directly write to the persistent storage using hardcoded values as above into locally defined external vars declared as so (not in the data layout struct)

```
extern uint16_t Flsun_language;//新增
  extern millis_t total_time;//新增
  extern uint8_t sd_filename_size;//新增
  bool MarlinSettings::save() {
```

Why is this important? Well one of the reasons that EEPROM storage was unstable, and also why language and print time would so frequently vanish is because the regular marlin settings would end up overwriting this hardcoded 960/970 space when running your custom firmware. I suspect that some additional settings you may have enabled/disabled caused the problem to show up but at the end of the day the implementation they did was just crude and bad. Here are logs that show:

```
SENDING:M500
echo:L574 POS is :100"
echo:settings: 624 Flsun language is :1"
echo:settings: 625 Total time is :0"
echo:attempting to write value :1"
echo:existing value is :0"
echo:attempting to write value :0"
echo:existing value is :0"
echo:L574 POS is :106"
echo:L574 POS is :107"
echo:L574 POS is :179"
echo:L574 POS is :195"
echo:L574 POS is :199"
echo:L574 POS is :211"
echo:L574 POS is :212"
echo:L574 POS is :216"
echo:L574 POS is :220"
echo:L574 POS is :224"
echo:L574 POS is :225"
echo:L574 POS is :226"
echo:L574 POS is :230"
echo:L574 POS is :234"
echo:L574 POS is :238"
echo:L574 POS is :242"
echo:L574 POS is :246"
echo:L574 POS is :250"
echo:L574 POS is :254"
echo:L574 POS is :258"
echo:L574 POS is :262"
echo:L574 POS is :274"
echo:L574 POS is :278"
echo:L574 POS is :282"
echo:L574 POS is :286"
echo:L574 POS is :290"
echo:L574 POS is :294"
echo:L574 POS is :298"
echo:L574 POS is :302"
echo:L574 POS is :306"
echo:L574 POS is :310"
echo:L574 POS is :311"
echo:L574 POS is :312"
echo:L574 POS is :320"
echo:L574 POS is :328"
echo:L574 POS is :652"
echo:L574 POS is :653"
echo:L574 POS is :654"
echo:L574 POS is :670"
echo:L574 POS is :671"
echo:L574 POS is :675"
echo:L574 POS is :687"
echo:L574 POS is :691"
echo:L574 POS is :695"
echo:L574 POS is :699"
echo:L574 POS is :711"
echo:L574 POS is :723"
echo:L574 POS is :735"
echo:L574 POS is :755"
echo:L574 POS is :757"
echo:L574 POS is :769"
echo:L574 POS is :770"
echo:L574 POS is :772"
echo:L574 POS is :778"
echo:L574 POS is :779"
echo:L574 POS is :811"
echo:L574 POS is :812"
echo:L574 POS is :813"
echo:L574 POS is :817"
echo:L574 POS is :821"
echo:L574 POS is :853"
echo:L574 POS is :917"
echo:L574 POS is :933"
echo:L574 POS is :949"
echo:L574 POS is :953"
echo:attempting to write value :0"
echo:existing value is :1"
echo:L574 POS is :965"
echo:attempting to write value :0"
echo:existing value is :0"
echo:L574 POS is :1073"
echo:L574 POS is :1085"
echo:L574 POS is :1093"
echo:L574 POS is :1105"
echo:L574 POS is :1106"
echo:L574 POS is :100"
echo:L574 POS is :104"
//action:notification Settings Stored
Not SD printing
Disconnected.
```

The "attempting to write" echo was placed in the low level eeprom_wired file right before the write operation and only fired with the original and proposed values when the "pos" variable was 960 or 970, and the "flsun language is" log message was placed right above the two write_data calls I quoted above. As you can see towards the end of the M500 operation a write was done to the 960/970 sectors that was not related to FLSun's explicit write_data commands.

My fix was just to throw out FLSun's settings.cpp and rebase from a clean copy pulled from Marlin's 2.0.8.1 release. I then added the two relevant FLSun specific fields (total time and language) back in by properly defining them in the data struct and having them written/read by the same relative position logic as all the other fields.

**That was one of the problems**

2. The default I2C pins for the EEPROM are not appropriate for the Robin Nano V3 board. This is a known and fixed issue in the main Marlin repo. I simply applied that fix in this PR. (https://github.com/MarlinFirmware/Marlin/pull/21174). Don't ask me what the deal is regarding this on the OEM FLSun firmware. They use the wrong pins too I think, so :shrug: :shrug: :shrug:

3. Due to the size of the mesh generated by the "Auto Level" UI function, the write operation to the EEPROM would time out. This would corrupt the EEPROM. In this case after power cycling the screen would hang with no text or temperature readout for 30-60 seconds. It would then restore the EEPROM to the default values in Config.h and resume operation. This is a known and fixed issue on the main Marlin project for the Nano V3 board but FLSun did not utilize the fix for whatever reason. This is a nasty bug that could cause all sorts of unpredictable weirdness even if you didn't turn your printer off after auto-leveling as the EEPROM would be entirely corrupted until the next reboot. (https://github.com/MarlinFirmware/Marlin/pull/21436)

4. I also pulled in a couple of adjacent fixes from the main project which may or may not improve stability
Prevent watchdog reset in setup() #21776 (https://github.com/MarlinFirmware/Marlin/pull/21776)
Blocking Move Followup 2 (fix delta failed probe) #21781 (https://github.com/MarlinFirmware/Marlin/pull/21781)

I also did some very minor cleanup in the core marlin file to put the FLSun language logic (I don't know why they didn't just tap into the existing Marlin language logic) and the FLSun print time update logic into their own functions. This made syncing them up with the data pulled from settings.cpp easier/cleaner.

### Benefits

I can turn my printer on and off now without fear for my, my cat's, or my printer's safety. Settings (including language!) do not reset to the configuration.h constants on power cycle. Missing text no longer occurs.

### Configurations

I use the same configuration as in the github project, but with a higher max_temp set.


![Alt Text](https://c.tenor.com/c5uUIPqKIiwAAAAd/cat-bane-funny-animals.gif)